### PR TITLE
Dev

### DIFF
--- a/src/main/java/human/est0y/chesslike/directions/BoardNavigator.java
+++ b/src/main/java/human/est0y/chesslike/directions/BoardNavigator.java
@@ -1,0 +1,5 @@
+package human.est0y.chesslike.directions;
+
+public interface BoardNavigator<CELL, DIRECTION extends Enum<DIRECTION>> {
+    CELL nextCell(CELL startCell, CELL boardSize, DIRECTION direction);
+}

--- a/src/main/java/human/est0y/chesslike/directions/EmptyCellDirection.java
+++ b/src/main/java/human/est0y/chesslike/directions/EmptyCellDirection.java
@@ -1,0 +1,12 @@
+package human.est0y.chesslike.directions;
+
+import human.est0y.chesslike.domain.Board;
+
+import java.util.List;
+
+public interface EmptyCellDirection<CELL, DIRECTION> {
+
+    List<CELL> getEmptyToOccupied(CELL cell, DIRECTION direction, Board<CELL, ?, ?, ?, ?> board);
+
+    List<CELL> getEmptyToOccupied(CELL cell, DIRECTION direction, Board<CELL, ?, ?, ?, ?> board, int maxPath);
+}

--- a/src/main/java/human/est0y/chesslike/directions/EmptySquareDirection.java
+++ b/src/main/java/human/est0y/chesslike/directions/EmptySquareDirection.java
@@ -1,0 +1,53 @@
+package human.est0y.chesslike.directions;
+
+import human.est0y.chesslike.domain.Board;
+import human.est0y.chesslike.domain.chess.Square;
+import human.est0y.chesslike.domain.squares.Direction;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class EmptySquareDirection implements EmptyCellDirection<Square, Direction> {
+
+    private final BoardNavigator<Square, Direction> boardNavigator;
+
+    @Override
+    public List<Square> getEmptyToOccupied(Square square, Direction direction, Board<Square, ?, ?, ?, ?> board) {
+        List<Square> squares = new ArrayList<>();
+        Square nowSquare = getNextEmptySquare(square, direction, board);
+        while (nowSquare != null) {
+            squares.add(nowSquare);
+            nowSquare = getNextEmptySquare(nowSquare, direction, board);
+        }
+        return squares;
+    }
+
+    @Override
+    public List<Square> getEmptyToOccupied(Square square, Direction direction, Board<Square, ?, ?, ?, ?> board,
+                                           int maxPath) {
+        List<Square> squares = new ArrayList<>();
+        for (int i = 1; i <= maxPath; i++) {
+            Square nowSquare = getNextEmptySquare(square, direction, board);
+            if (nowSquare == null) {
+                break;
+            }
+            squares.add(nowSquare);
+            square = nowSquare;
+        }
+        return squares;
+    }
+
+    private Square getNextEmptySquare(Square square, Direction direction, Board<Square, ?, ?, ?, ?> board) {
+        try {
+            Square nextSquare = boardNavigator.nextCell(square, board.getBoardSize(), direction);
+            if (board.getPiece(nextSquare).isEmpty()) {
+                return nextSquare;
+            }
+        } catch (NotExistSquareException | NullPointerException e) {
+            return null;
+        }
+        return null;
+    }
+}

--- a/src/main/java/human/est0y/chesslike/directions/NotExistSquareException.java
+++ b/src/main/java/human/est0y/chesslike/directions/NotExistSquareException.java
@@ -1,0 +1,7 @@
+package human.est0y.chesslike.directions;
+
+public class NotExistSquareException extends RuntimeException {
+    public NotExistSquareException(int newX, int newY) {
+        super(newX + "," + newY);
+    }
+}

--- a/src/main/java/human/est0y/chesslike/directions/SquareBoardNavigator.java
+++ b/src/main/java/human/est0y/chesslike/directions/SquareBoardNavigator.java
@@ -1,0 +1,41 @@
+package human.est0y.chesslike.directions;
+
+import human.est0y.chesslike.domain.chess.Square;
+import human.est0y.chesslike.domain.squares.Direction;
+import human.est0y.chesslike.squares.SquareCache;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SquareBoardNavigator implements BoardNavigator<Square, Direction> {
+
+    private final SquareCache squareCache;
+
+    @Override
+    public Square nextCell(Square startCell, Square boardSize, Direction direction) {
+        return switch (direction) {
+            case UNKNOWN -> throw new IllegalArgumentException("Direction is UNKNOWN");
+            case UP -> nextSquare(startCell, boardSize, 0, 1);
+            case DOWN -> nextSquare(startCell, boardSize, 0, -1);
+            case LEFT -> nextSquare(startCell, boardSize, -1, 0);
+            case RIGHT -> nextSquare(startCell, boardSize, 1, 0);
+            case LEFT_UP -> nextSquare(startCell, boardSize, -1, 1);
+            case LEFT_DOWN -> nextSquare(startCell, boardSize, -1, -1);
+            case RIGHT_UP -> nextSquare(startCell, boardSize, 1, 1);
+            case RIGHT_DOWN -> nextSquare(startCell, boardSize, 1, -1);
+        };
+    }
+
+    private Square nextSquare(Square square, Square boardSize, int horizontalTerm, int verticalTerm) {
+        var x = square.getX();
+        var y = square.getY();
+        var newX = x + horizontalTerm;
+        var newY = y + verticalTerm;
+        var maxX = boardSize.getX();
+        var maxY = boardSize.getY();
+        if (newX <= maxX && newY <= maxY && newX > 0 && newY > 0) {
+            return squareCache.getSquare(newX, newY);
+        } else {
+            throw new NotExistSquareException(newX, newY);
+        }
+    }
+}

--- a/src/main/java/human/est0y/chesslike/domain/squares/Direction.java
+++ b/src/main/java/human/est0y/chesslike/domain/squares/Direction.java
@@ -1,0 +1,25 @@
+package human.est0y.chesslike.domain.squares;
+
+import lombok.Getter;
+
+@Getter
+public enum Direction {
+    UP(true, false),
+    DOWN(true, false),
+    LEFT(true, false),
+    RIGHT(true, false),
+    LEFT_UP(false,true),
+    LEFT_DOWN(false,true),
+    RIGHT_UP(false,true),
+    RIGHT_DOWN(false,true),
+    UNKNOWN(false,false);
+
+    private final boolean isOrthogonal;
+
+    private final boolean isDiagonal;
+
+    Direction(boolean isOrthogonal, boolean isDiagonal) {
+        this.isOrthogonal = isOrthogonal;
+        this.isDiagonal = isDiagonal;
+    }
+}

--- a/src/test/java/human/est0y/chesslike/directions/EmptySquareDirectionTest.java
+++ b/src/test/java/human/est0y/chesslike/directions/EmptySquareDirectionTest.java
@@ -1,0 +1,56 @@
+package human.est0y.chesslike.directions;
+
+import human.est0y.chesslike.domain.Board;
+import human.est0y.chesslike.domain.Piece;
+import human.est0y.chesslike.domain.chess.Square;
+import human.est0y.chesslike.domain.squares.Direction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EmptySquareDirectionTest {
+
+    @Mock
+    private BoardNavigator<Square, Direction> boardNavigator;
+
+    @Mock
+    private Board<Square, ?, ?, ?, ?> board;
+
+    @Test
+    void getEmptyToOccupied() {
+        when(board.getBoardSize()).thenReturn(new Square(8,8));
+        when(boardNavigator.nextCell(new Square(1, 1), new Square(8, 8), Direction.RIGHT))
+                .thenReturn(new Square(2, 1));
+        when(boardNavigator.nextCell(new Square(2, 1), new Square(8, 8), Direction.RIGHT))
+                .thenReturn(new Square(3, 1));
+        when(board.getPiece(any(Square.class))).thenReturn(Optional.empty());
+        when(board.getPiece(new Square(3, 1))).thenReturn(Optional.of(new Piece<>(null,null,null)));
+        var em = new EmptySquareDirection(boardNavigator);
+        var squares = em.getEmptyToOccupied(new Square(1, 1), Direction.RIGHT, board);
+        Assertions.assertEquals(squares.get(0),new Square(2,1));
+
+    }
+
+    @Test
+    void testGetEmptyToOccupied() {
+        when(board.getBoardSize()).thenReturn(new Square(8,8));
+        when(boardNavigator.nextCell(new Square(1, 1), new Square(8, 8), Direction.RIGHT))
+                .thenReturn(new Square(2, 1));
+        when(boardNavigator.nextCell(new Square(2, 1), new Square(8, 8), Direction.RIGHT))
+                .thenReturn(new Square(3, 1));
+        when(board.getPiece(any(Square.class))).thenReturn(Optional.empty());
+        when(board.getPiece(new Square(3, 1))).thenReturn(Optional.of(new Piece<>(null,null,null)));
+        var em = new EmptySquareDirection(boardNavigator);
+        var squares = em.getEmptyToOccupied(new Square(1, 1), Direction.RIGHT, board,2);
+        Assertions.assertEquals(squares.get(0),new Square(2,1));
+    }
+}

--- a/src/test/java/human/est0y/chesslike/directions/SquareBoardNavigatorTest.java
+++ b/src/test/java/human/est0y/chesslike/directions/SquareBoardNavigatorTest.java
@@ -1,0 +1,33 @@
+package human.est0y.chesslike.directions;
+
+import human.est0y.chesslike.domain.chess.Square;
+import human.est0y.chesslike.domain.squares.Direction;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SquareBoardNavigatorTest {
+
+    private final SquareBoardNavigator navigator = new SquareBoardNavigator(Square::new);
+
+    @Test
+    void nextCell() {
+        Assertions.assertEquals(new Square(4, 5), nextSquare(Direction.LEFT));
+        Assertions.assertEquals(new Square(6, 5), nextSquare(Direction.RIGHT));
+        Assertions.assertEquals(new Square(5, 6), nextSquare(Direction.UP));
+        Assertions.assertEquals(new Square(5, 4), nextSquare(Direction.DOWN));
+        Assertions.assertEquals(new Square(4, 6), nextSquare(Direction.LEFT_UP));
+        Assertions.assertEquals(new Square(4, 4), nextSquare(Direction.LEFT_DOWN));
+        Assertions.assertEquals(new Square(6, 6), nextSquare(Direction.RIGHT_UP));
+        Assertions.assertEquals(new Square(6, 4), nextSquare(Direction.RIGHT_DOWN));
+    }
+
+    @Test
+    void nextCellOutOfBoard() {
+        Assertions.assertThrows(NotExistSquareException.class,
+                () -> navigator.nextCell(new Square(5, 5), new Square(5, 5), Direction.RIGHT));
+    }
+
+    private Square nextSquare(Direction direction) {
+        return navigator.nextCell(new Square(5, 5), new Square(8, 8), direction);
+    }
+}


### PR DESCRIPTION
add classes to traverse the board

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces interfaces and classes to navigate a chess-like board and find empty squares in specific directions.

### Detailed summary
- Added `BoardNavigator` interface for board navigation
- Added `NotExistSquareException` for out-of-board squares
- Implemented `EmptyCellDirection` for finding empty squares
- Added `Direction` enum with orthogonal and diagonal flags
- Created `SquareBoardNavigator` for square-specific navigation
- Implemented `EmptySquareDirection` for finding empty squares in a direction
- Added tests for `SquareBoardNavigator` and `EmptySquareDirection`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->